### PR TITLE
Add check if PHP can delete a screenshot

### DIFF
--- a/src/Capture.php
+++ b/src/Capture.php
@@ -145,7 +145,7 @@ class Capture
             $data['userAgent'] = $this->userAgentString;
         }
 
-        if ($deleteFileIfExists && file_exists($outputPath)) {
+        if ($deleteFileIfExists && file_exists($outputPath) && is_writable($outputPath)) {
             unlink($outputPath);
         }
 


### PR DESCRIPTION
In my project, I'm writing screenshots to `/tmp` and PHP doesn't have permissions to delete from `/tmp` folder. 
This additional check is needed to prevent throwing `Warning: unlink(/tmp/screenshot.jpg): Operation not permitted`