### PR TITLE
Add ability to set custom path to PhantomJS binary

### DIFF
--- a/src/Capture.php
+++ b/src/Capture.php
@@ -185,8 +185,8 @@ class Capture
     public function setBinPath($binPath)
     {
         $binPath = rtrim($binPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-        if (!file_exists($binPath . 'phantomjs')) {
-            throw new \Exception("Bin directory should contain the phantomjs file!");
+        if (!file_exists($binPath . 'phantomjs') && !file_exists($binPath . 'phantomjs.exe')) {
+            throw new \Exception("Bin directory should contain phantomjs or phantomjs.exe file!");
         }
         $this->binPath = $binPath;
     }

--- a/src/Capture.php
+++ b/src/Capture.php
@@ -178,6 +178,20 @@ class Capture
     }
 
     /**
+     * Sets the path to PhantomJS binary, example: "/usr/bin"
+     *
+     * @param string $path
+     */
+    public function setBinPath($binPath)
+    {
+        $binPath = rtrim($binPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        if (!file_exists($binPath . 'phantomjs')) {
+            throw new \Exception("Bin directory should contain the phantomjs file!");
+        }
+        $this->binPath = $binPath;
+    }
+
+    /**
      * Sets the url to screenshot
      *
      * @param string $url URL


### PR DESCRIPTION
In some cases, it may be necessary to use phantomjs binary installed via `apt-get` or some other package manager. 

This PR adds ability to set custom path to phantomjs binary if needed.