### PR TITLE
Cast the URL to string to prevent empty object serialization

### DIFF
--- a/src/Capture.php
+++ b/src/Capture.php
@@ -167,7 +167,7 @@ class Capture
         }
 
         $data = array(
-            'url'           => $this->url,
+            'url'           => (string) $this->url,
             'width'         => $this->width,
             'height'        => $this->height,
             'imageLocation' => LocalPath::sanitize($this->imageLocation),


### PR DESCRIPTION
The `$url` variable is currently a instance of the `Url` class, which only has a protected variable. When the json_encode method is called, an empty object is returned. This results in that every job with a different URL gets the same job name (if the other settings remain the same).

Could also implement the `JsonSerializable` class in the `Url` class. Let me know what you prefer.