### PR TITLE
Add render delay option

### DIFF
--- a/src/Capture.php
+++ b/src/Capture.php
@@ -83,6 +83,13 @@ class Capture
      * @var int
      */
     protected $timeout = 0;
+    
+     /**
+     * Sets the delay period
+     *
+     * @var int
+     */
+    protected $delay = 0;
 
     /**
      * Bin directory, should contain the phantomjs file, otherwise it won't work
@@ -202,6 +209,10 @@ class Capture
 
         if ($this->timeout) {
             $data['timeout'] = $this->timeout;
+        }
+        
+        if ($this->delay) {
+            $data['delay'] = $this->delay;
         }
 
         if ($this->includedJsScripts) {
@@ -441,6 +452,23 @@ class Capture
         return $this;
     }
 
+    /**
+     * Sets the delay period
+     *
+     * @param int $delay Delay period
+     *
+     * @return Capture
+     * @throws InvalidArgumentException
+     */
+    public function setDelay($delay)
+    {
+        if (!is_numeric($delay)) {
+            throw new InvalidArgumentException('The delay value must be a number.');
+        }
+        $this->delay = $delay;
+
+        return $this;
+    }
     /**
      * Adds a JS script or snippet to the screen shot script
      *

--- a/templates/screen-capture.php
+++ b/templates/screen-capture.php
@@ -41,6 +41,8 @@ page.open('<?php echo $url ?>', function (status) {
         <?php endif ?>
     });
 
-    page.render('<?php echo $imageLocation ?>');
-    phantom.exit();
+    setTimeout(function() {
+            page.render('<?php echo $imageLocation ?>');
+            phantom.exit();
+    }, <?php echo (isset($delay) ? $delay : 0); ?>);
 });


### PR DESCRIPTION
I noticed that a `delay` feature was commonly requested in your issue que ( #5, #27, maybe #61, and my own #75 ). This patch will allow the user to set 

```
$screenCapture->setDelay(3000);
```
for a 3 second delay in a very convenient way.