### PR TITLE
Removed use of ::class not supported by PHP < 5.5

### DIFF
--- a/src/Capture.php
+++ b/src/Capture.php
@@ -518,7 +518,7 @@ class Capture
      */
     public function includeJs($script)
     {
-        if (is_a($script, Url::class)) {
+        if ($script instanceof Url) {
             $this->includedJsScripts[] = $script;
         } else {
             $this->includedJsSnippets[] = $script;

--- a/src/Image/Types.php
+++ b/src/Image/Types.php
@@ -9,8 +9,8 @@ use Screen\Image\Types\Type;
 class Types
 {
     protected static $typesMap = array(
-        Jpg::FORMAT => Jpg::class,
-        Png::FORMAT => Png::class,
+        Jpg::FORMAT => 'Screen\Image\Types\Jpg',
+        Png::FORMAT => 'Screen\Image\Types\Png',
     );
 
     /**


### PR DESCRIPTION
The composer.json file says PHP 5.3 or later is supported but the use of ::class causes parse errors on PHP versions older than 5.5.